### PR TITLE
Add demos to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# demo
+# Probot Demos
+
+[Probot](https://github.com/probot/probot) is bot framework for GitHub. This repository has some demos of some of the cool things you can build with it.
+
+Check out these examples:
+
+- Check out [#2](https://github.com/probot/demo/issues/2) for a demo of the [autoresponder](https://github.com/probot/autoresponder) and [stale](https://github.com/probot/stale) plugins.


### PR DESCRIPTION
This adds links to the interesting demos to the README.

---

Also, this pull request is a demo of the [owners](https://github.com/probot/owners) plugin, which should comment 👇  with @mentions of people listed in the [OWNERS](https://github.com/probot/demo/blob/master/OWNERS) file.