### PR TITLE
Demo of probot/configurer

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,11 @@
+repository:
+  description: demos of cool things you can do with Probot
+  has_wiki: false
+
+labels:
+  - name: stale
+    color: ededed
+  - name: question
+    color: cc317c
+  - name: wontfix
+    color: ffffff

--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ Check out these examples:
 
 - [#2](https://github.com/probot/demo/issues/2) shows the [autoresponder](https://github.com/probot/autoresponder) and [stale](https://github.com/probot/stale) plugins
 - [#3](https://github.com/probot/demo/pull/3) shows the [owners](https://github.com/probot/autoresponder) plugin
+- [#5](https://github.com/probot/demo/pull/5) shows the the [configurer](https://github.com/probot/configurer) plugin, which enables Pull Requests for GitHub repository settings.
+ 


### PR DESCRIPTION
This is a demo of the [configurer](https://github.com/probot/configurer) plugin, which enables Pull Requests for GitHub repository settings.

Once this Pull Request is merged, then all of the settings in [`.github/config.yml`](https://github.com/probot/demo/blob/master/.github/config.yml) will be synced to this repository.

Want to make your repository public? Open a pull request to set `private: false`. Want to change the default branch from master? Set `defaul_branch: gh-pages`.

Check out the [probot/configurer](https://github.com/probot/configurer) repo for more information and docs.

